### PR TITLE
Add "platform" to "repo" object in API

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ openFPGA Cores Inventory provides a read-only API for developers.
 ### Cores
 
 #### Getting the list of cores
-Returns a list of all available cores for the Analogue Pocket. 
+Returns a list of all available cores for the Analogue Pocket.
 
 ```
 GET https://joshcampbell191.github.io/openfpga-cores-inventory/api/v0/analogue-pocket/cores.json
@@ -84,11 +84,11 @@ Where a core object is:
 
 Where a repo object is:
 
-| Field             | Type   | Description                                                               |
-| ------------------|--------|---------------------------------------------------------------------------|
-| host              | enum   | The website that hosts the repo. Currently, this always returns "github". |
-| user              | string | The core developer's GitHub username.                                     |
-| project           | string | The core's GitHub repository name.                                        |
+| Field             | Type   | Description                                                                     |
+| ------------------|--------|---------------------------------------------------------------------------------|
+| platform          | enum   | The website where the repo is located. Currently, this always returns "github". |
+| user              | string | The core developer's GitHub username.                                           |
+| project           | string | The core's GitHub repository name.                                              |
 
 Where an asset object is:
 

--- a/README.md
+++ b/README.md
@@ -84,10 +84,11 @@ Where a core object is:
 
 Where a repo object is:
 
-| Field             | Type   | Description                           |
-| ------------------|--------|---------------------------------------|
-| user              | string | The core developer's GitHub username. |
-| project           | string | The core's GitHub repository name.    |
+| Field             | Type   | Description                                                               |
+| ------------------|--------|---------------------------------------------------------------------------|
+| host              | enum   | The website that hosts the repo. Currently, this always returns "github". |
+| user              | string | The core developer's GitHub username.                                     |
+| project           | string | The core's GitHub repository name.                                        |
 
 Where an asset object is:
 

--- a/api/v0/analogue-pocket/cores.json
+++ b/api/v0/analogue-pocket/cores.json
@@ -7,6 +7,7 @@ layout: none
     {%- for core in developer.cores %}
     {
       "repo": {
+        "host": "github",
         "user": {{ developer.username | jsonify }},
         "project": {{ core.repo | jsonify }}
       },

--- a/api/v0/analogue-pocket/cores.json
+++ b/api/v0/analogue-pocket/cores.json
@@ -7,7 +7,7 @@ layout: none
     {%- for core in developer.cores %}
     {
       "repo": {
-        "host": "github",
+        "platform": "github",
         "user": {{ developer.username | jsonify }},
         "project": {{ core.repo | jsonify }}
       },


### PR DESCRIPTION
A [reddit comment](https://www.reddit.com/r/AnaloguePocket/comments/xmeo3m/comment/ippecse/?utm_source=share&utm_medium=web2x&context=3) suggested that we add the repo host to the API response. It's very possible in the future that cores may be hosted on another site, like GitLab or BitBucket, so adding this from the start would save us some pain in the future.

For right now, I hard coded it straight into the JSON response, instead of adding it to each core in the YAML file. I figure we keep the YAML as clean as possible until we actually need to track other hosting sites.