### PR TITLE
Added support for DataTables

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ source "https://rubygems.org"
 # Happy Jekylling!
 #gem "jekyll", "~> 4.2.2"
 # This is the default theme for new Jekyll sites. You may change this to anything you like.
-gem "minima", "~> 2.5.1"
+gem "minima", github: "jekyll/minima"
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and
 # uncomment the line below. To upgrade, run `bundle update github-pages`.
 gem "github-pages", "~> 227", group: :jekyll_plugins

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,12 @@
+GIT
+  remote: https://github.com/jekyll/minima.git
+  revision: 41b97699af658128fa9983e5312ca5516641f335
+  specs:
+    minima (2.5.1)
+      jekyll (>= 3.5, < 5.0)
+      jekyll-feed (~> 0.9)
+      jekyll-seo-tag (~> 2.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -207,10 +216,6 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.3.6)
     mini_portile2 (2.8.0)
-    minima (2.5.1)
-      jekyll (>= 3.5, < 5.0)
-      jekyll-feed (~> 0.9)
-      jekyll-seo-tag (~> 2.1)
     minitest (5.16.3)
     nokogiri (1.13.8)
       mini_portile2 (~> 2.8.0)
@@ -263,7 +268,7 @@ DEPENDENCIES
   github-pages (~> 227)
   http_parser.rb (~> 0.6.0)
   jekyll-feed (~> 0.15.1)
-  minima (~> 2.5.1)
+  minima!
   tzinfo (~> 1.2)
   tzinfo-data
   wdm (~> 0.1.1)

--- a/_config.yml
+++ b/_config.yml
@@ -19,16 +19,23 @@
 # in the templates via {{ site.myvariable }}.
 
 title: openFPGA Cores Inventory
-email: ""
+author:
+  name:
+  email:
 description: >- # this means to ignore newlines until "baseurl:"
   This site was created to document openFPGA cores and their related devices.
 domain: joshcampbell191.github.io
 baseurl: "/openfpga-cores-inventory" # the subpath of your site, e.g. /blog
 url: https://joshcampbell191.github.io # the base hostname & protocol for your site, e.g. http://example.com
-github_username: joshcampbell191
 
 # GitHub settings
 markdown: kramdown
+
+# Minima settings
+minima:
+  social_links:
+    twitter: joshcampbell191
+    github: joshcampbell191
 
 # Build settings
 theme: minima

--- a/_data/cores.yml
+++ b/_data/cores.yml
@@ -52,7 +52,7 @@
     - repo: openfpga-lunarlander
       display_name: Lunar Lander for Analogue Pocket
       identifier: ericlewis.LunarLander
-      platform: LunarLander
+      platform: Lunar Lander
       assets:
         location: Assets/lunarlander/ericlewis.LunarLander/
         files:
@@ -61,7 +61,7 @@
     - repo: openfpga-spacerace
       display_name: Space Race for Analogue Pocket
       identifier: ericlewis.SpaceRace
-      platform: SpaceRace
+      platform: Space Race
     - repo: openfpga-superbreakout
       display_name: Super Breakout for Analogue Pocket
       identifier: ericlewis.SuperBreakout
@@ -182,7 +182,7 @@
     - repo: openFPGA-GBA
       display_name: Spiritualized GBA
       identifier: Spiritualized.GBA
-      platform: Gameboy Advance
+      platform: Game Boy Advance
       assets:
         location: Assets/gba/common/
         files:
@@ -191,7 +191,7 @@
     - repo: openFPGA-GB-GBC
       display_name: Spiritualized GB & GBC
       identifier: Spiritualized.GBC
-      platform: Gameboy/Gameboy Color
+      platform: Game Boy / Game Boy Color
       assets:
         location: Assets/gbc/common/
         files:

--- a/_includes/custom-head.html
+++ b/_includes/custom-head.html
@@ -1,0 +1,3 @@
+<link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/dt/jq-3.6.0/dt-1.12.1/fh-3.2.4/datatables.min.css"/>
+<script type="text/javascript" src="https://cdn.datatables.net/v/dt/jq-3.6.0/dt-1.12.1/fh-3.2.4/datatables.min.js"></script>
+<script type="text/javascript" src="{{ "/assets/js/script.js" | relative_url }}"></script>

--- a/analogue-pocket.md
+++ b/analogue-pocket.md
@@ -5,25 +5,35 @@
 layout: page
 title: Analogue Pocket
 ---
-<script>
-  function sortTable() {
-    const tableBody = document.querySelector("tbody");
-    const tableRows = tableBody.querySelectorAll("tr");
-    [...tableRows]
-      .sort((a, b) => a.innerText > b.innerText ? 1 : -1)
-      .forEach(row => tableBody.appendChild(row))
-  }
-  document.addEventListener("DOMContentLoaded", sortTable)
-</script>
-
 The [Analogue Pocket](https://www.analogue.co/pocket) is a multi-video-game-system portable handheld designed and built by [Analogue](https://www.analogue.co).
 
 ## Cores
 
-| Name | Platform | Author | Release | Release Date |
-| ---- | -------- | ------ | ------- | ------------ |
-{% for developer in site.data.cores -%}
-{% for core in developer.cores -%}
-| [{{ core.display_name }}](https://github.com/{{ developer.username }}/{{ core.repo }}) | {{ core.platform }} | [{{ developer.username }}](https://github.com/{{ developer.username }}) | [![release](https://img.shields.io/github/v/release/{{ developer.username }}/{{ core.repo }}?include_prereleases)](https://github.com/{{ developer.username }}/{{ core.repo }}/releases/latest) | ![GitHub Release Date](https://img.shields.io/github/release-date-pre/{{ developer.username }}/{{ core.repo }}) |
-{% endfor -%}
-{% endfor -%}
+<table class="datatable">
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Platform</th>
+      <th>Author</th>
+      <th class="no-sort">Version</th>
+      <th class="no-sort">Release Date</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for developer in site.data.cores -%}
+      {% for core in developer.cores -%}
+        <tr>
+          <td><a href="https://github.com/{{ developer.username }}/{{ core.repo }}">{{ core.display_name }}</a></td>
+          <td>{{ core.platform }}</td>
+          <td><a href="https://github.com/{{ developer.username }}">{{ developer.username }}</a></td>
+          <td>
+            <a href="https://github.com/{{ developer.username }}/{{ core.repo }}/releases/latest">
+              <img src="https://img.shields.io/github/v/release/{{ developer.username }}/{{ core.repo }}?include_prereleases&label=" alt="release">
+            </a>
+          </td>
+          <td><img src="https://img.shields.io/github/release-date-pre/{{ developer.username }}/{{ core.repo }}?label=" alt="GitHub Release Date"></td>
+        </tr>
+      {% endfor -%}
+    {% endfor -%}
+  </tbody>
+</table>

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -1,0 +1,10 @@
+$(document).ready(function () {
+    $('.datatable').DataTable({
+        fixedHeader: true,
+        info: false,
+        paging: false,
+        columnDefs: [
+            { targets: 'no-sort', orderable: false }
+        ]
+    });
+});


### PR DESCRIPTION
I took some inspiration from PR #13 and added a few minor changes. 

- You'll notice that I kept the markdown format as it's a bit easier on the formatting. 
- By pulling the latest minima theme from GitHub as opposed to gem, you'll notice that we only have to override the `custom-head.html` in order to add our own custom styles / scripts.
  - This version also allows us to implement the `dark` skin to the site if we choose to do so.
- I removed the label next to the images from shield.io (by setting a blank label). This allows for larger images in the page content making it easier to read.
