### PR TITLE
Add Mad Planets to multi-repo hack

### DIFF
--- a/.github/workflows/core_data_generator.rb
+++ b/.github/workflows/core_data_generator.rb
@@ -89,9 +89,16 @@ module GitHub
       [stable]
     end
 
-    # Hack for the openFPGA-GB-GBC repo that hosts cores for both the GB & GBC.
+    # HACK: for repositories that contain multiple cores.
     def choose_asset(assets)
-      index = display_name == "Spiritualized GB" ? 1 : 0
+      index = case display_name
+              when "Mad Planets"
+                1
+              when "Spiritualized GB"
+                1
+              else
+                0
+              end
       assets[index]
     end
 


### PR DESCRIPTION
The [Q*Bert repo](https://github.com/ericlewis/openfpga-qbert) is going to be updated with another asset for Mad Planets, similar to the GB/GBC repository. Adding this preemptively for when it is released.